### PR TITLE
Mark interface methods as pure

### DIFF
--- a/src/Typeclass/Applicative.php
+++ b/src/Typeclass/Applicative.php
@@ -17,6 +17,7 @@ interface Applicative extends Apply
      * @psalm-param B $a
      * @return Applicative
      * @psalm-return Applicative<F, B>
+     * @psalm-pure
      */
     public static function pure($a): Applicative;
 }

--- a/src/Typeclass/Apply.php
+++ b/src/Typeclass/Apply.php
@@ -17,6 +17,7 @@ interface Apply extends Functor
      * @psalm-param Apply<F, callable(A): B> $f
      * @return Apply
      * @psalm-return Apply<F, B>
+     * @psalm-pure
      */
     public function apply(Apply $f): Apply;
 }

--- a/src/Typeclass/Functor.php
+++ b/src/Typeclass/Functor.php
@@ -19,6 +19,7 @@ interface Functor extends HK
      * @psalm-param callable(A): B $f
      * @return Functor
      * @psalm-return Functor<F, B>
+     * @psalm-pure
      */
     public function map(
         callable $f


### PR DESCRIPTION
I was playing around with this package and noticed that the interface methods are not marked as pure (causing some issues in psalm [in my implementation](https://github.com/veewee/happy-helpers/blob/master/src/iterables/map.php)). 
