### PR TITLE
Implements `semigroup` instances

### DIFF
--- a/src/Instances/Semigroup/AndSemigroup.php
+++ b/src/Instances/Semigroup/AndSemigroup.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marcosh\LamPHPda\Instances\Semigroup;
+
+use Marcosh\LamPHPda\Typeclass\Semigroup;
+
+/**
+ * @template A
+ *
+ * @implements Semigroup<A>
+ *
+ * @psalm-immutable
+ */
+final class AndSemigroup implements Semigroup
+{
+    /**
+     * @param A $a
+     * @param A $b
+     * @return A
+     *
+     * @psalm-pure
+     */
+    public function append($a, $b)
+    {
+        return $a && $b;
+    }
+}

--- a/src/Instances/Semigroup/IntAdditionSemigroup.php
+++ b/src/Instances/Semigroup/IntAdditionSemigroup.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marcosh\LamPHPda\Instances\Semigroup;
+
+use Marcosh\LamPHPda\Typeclass\Semigroup;
+
+/**
+ * @template A
+ *
+ * @implements Semigroup<A>
+ *
+ * @psalm-immutable
+ */
+final class IntAdditionSemigroup implements Semigroup
+{
+    /**
+     * @param A $a
+     * @param A $b
+     * @return A
+     *
+     * @psalm-pure
+     */
+    public function append($a, $b)
+    {
+        return $a + $b;
+    }
+}

--- a/src/Instances/Semigroup/IntMultiplicationSemigroup.php
+++ b/src/Instances/Semigroup/IntMultiplicationSemigroup.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marcosh\LamPHPda\Instances\Semigroup;
+
+use Marcosh\LamPHPda\Typeclass\Semigroup;
+
+/**
+ * @template A
+ *
+ * @implements Semigroup<A>
+ *
+ * @psalm-immutable
+ */
+final class IntMultiplicationSemigroup implements Semigroup
+{
+    /**
+     * @param A $a
+     * @param A $b
+     * @return A
+     *
+     * @psalm-pure
+     */
+    public function append($a, $b)
+    {
+        return $a * $b;
+    }
+}

--- a/src/Instances/Semigroup/OrSemigroup.php
+++ b/src/Instances/Semigroup/OrSemigroup.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marcosh\LamPHPda\Instances\Semigroup;
+
+use Marcosh\LamPHPda\Typeclass\Semigroup;
+
+/**
+ * @template A
+ *
+ * @implements Semigroup<A>
+ *
+ * @psalm-immutable
+ */
+final class OrSemigroup implements Semigroup
+{
+    /**
+     * @param A $a
+     * @param A $b
+     * @return A
+     *
+     * @psalm-pure
+     */
+    public function append($a, $b)
+    {
+        return $a || $b;
+    }
+}

--- a/src/Instances/Semigroup/StringSemigroup.php
+++ b/src/Instances/Semigroup/StringSemigroup.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marcosh\LamPHPda\Instances\Semigroup;
+
+use Marcosh\LamPHPda\Typeclass\Semigroup;
+
+/**
+ * @template A
+ *
+ * @implements Semigroup<A>
+ *
+ * @psalm-immutable
+ */
+final class StringSemigroup implements Semigroup
+{
+    /**
+     * @param A $a
+     * @param A $b
+     * @return A
+     *
+     * @psalm-pure
+     */
+    public function append($a, $b)
+    {
+        return $a . $b;
+    }
+}


### PR DESCRIPTION
This PR implements:

- [x] `AndSemigroup`
- [x] `OrSemigroup`
- [x] `StringSemigroup`
- [x] `IntAdditionSemigroup`
- [x] `IntMultiplicationSemigroup`

Could you please let me know if this is the right way? I'll wait for your feeback before going further.