### PR TITLE
allow widening return type of Maybe::withDefault()

### DIFF
--- a/src/Maybe.php
+++ b/src/Maybe.php
@@ -122,8 +122,9 @@ final class Maybe implements DefaultMonad, DefaultTraversable
     }
 
     /**
-     * @param A $a
-     * @return A
+     * @template B
+     * @param B $a
+     * @return A|B
      */
     public function withDefault($a)
     {


### PR DESCRIPTION
Consider having `Maybe<string>`, which you want to unwrap and default to `null`, for example.

BTW, I think `withDefault()` is overly long and doesn't reveal the intent correctly: sounds like you "attach some default value to the Maybe", probably something like `unwrap()` could be a better name for this method. Or, perhaps `eval()` could be extended such that `$ifJust` callable is optional? The body of `Maybe::eval()` suggests that in past `$ifJust` was indeed optional.